### PR TITLE
Initial support for metals status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # About
 A sublime plugin for [Metals](https://scalameta.org/metals/) proving status bar support and other custom Metals LSP endpoints.
 
-# Installation 
-Clone the project into the Packages directory of sublime. 
+# Installation and usage
+1. install sublime [LSP](https://github.com/tomv564/LSP) plugin
+2. install [Metals](https://scalameta.org/metals/) while setting `--java-opt -Dmetals.status-bar=on` in the coursier command 
+3. Clone the project into the Packages directory of sublime. 
 ```
 # macOS
 ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/
 # Ubuntu
 ~/.config/sublime-text-3/Packages/
 ```
+4. Enable "metals-sublime" in your scala project

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# metals-sublime
+# About
+A sublime plugin for [Metals](https://scalameta.org/metals/) proving status bar support and other custom Metals LSP endpoints.
+
+# Installation 
+Clone the project into the Packages directory of sublime. 
+```
+# macOS
+~/Library/Application\ Support/Sublime\ Text\ 3/Packages/
+# Ubuntu
+~/.config/sublime-text-3/Packages/
+```

--- a/plugin.py
+++ b/plugin.py
@@ -1,0 +1,66 @@
+import shutil
+import sublime
+from LSP.plugin.core.handlers import LanguageHandler
+from LSP.plugin.core.settings import ClientConfig, LanguageConfig
+
+config_name = 'metals-sublime'
+server_name = 'metals-sublime'
+service_name = "metals-sublime"
+metals_config = ClientConfig(
+    name=config_name,
+    binary_args=[service_name],
+    tcp_port=None,
+    languages=[
+        LanguageConfig(
+            "scala",
+            ["source.scala"],
+            ["Packages/Scala/Scala.sublime-syntax"]
+        )
+    ],
+    enabled=False,
+    init_options=dict(),
+    settings=dict(),
+    env=dict())
+
+
+def metals_is_running() -> bool:
+    return shutil.which(service_name) is not None
+
+
+class LspMetalsPlugin(LanguageHandler):
+    def __init__(self):
+        self._name = config_name
+        self._config = metals_config
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def config(self) -> ClientConfig:
+        return self._config
+
+    def on_start(self, window) -> bool:
+        if not metals_is_running():
+            window.status_message(
+                "Metals must be installed run {}".format(server_name))
+            return False
+        return True
+
+    def on_initialized(self, client) -> None:
+        register_client(client)
+
+
+def register_client(client):
+    client.on_notification(
+        "metals/status",
+        lambda params: on_metals_status(params))
+
+
+def on_metals_status(params):
+    view = sublime.active_window().active_view()
+    hide = params.get('hide', False)
+    if(hide):
+        view.erase_status(server_name)
+    else:
+        view.set_status(server_name, params.get('text', ''))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
Support `metals/status` but given sublime API limitation unfortunately `tooltip` and `command` can't be handled.

![Peek 2019-09-14 22-39](https://user-images.githubusercontent.com/1632384/64913444-a35a6580-d740-11e9-9252-ab0f7553bd0b.gif)


Having a dedicated plugin for Metals should allows us to simply the installation. 
[Manually trigger build import](https://scalameta.org/metals/docs/editors/sublime.html#manually-trigger-build-import), [Tweaking Sublime Text for a better productivity](https://scalameta.org/metals/docs/editors/sublime.html#tweaking-sublime-text-for-a-better-productivity) and key mappings should work out of the box.

And we can further handle other custom endpoints 