### PR TITLE
Add common server commands

### DIFF
--- a/metals-sublime.sublime-commands
+++ b/metals-sublime.sublime-commands
@@ -1,0 +1,6 @@
+[
+    { "caption": "LSP-metals: Build Import", "command": "lsp_execute", "args":{"command_name": "build-import"}},
+    { "caption": "LSP-metals: Build Connect", "command": "lsp_execute", "args":{"command_name": "build-connect"}},
+    { "caption": "LSP-metals: Source Scan", "command": "lsp_execute", "args":{"command_name": "sources-scan"}},
+    { "caption": "LSP-metals: Doctor Run", "command": "lsp_execute", "args":{"command_name": "doctor-run"}}
+]

--- a/metals-sublime.sublime-commands
+++ b/metals-sublime.sublime-commands
@@ -1,6 +1,7 @@
 [
     { "caption": "LSP-metals: Build Import", "command": "lsp_execute", "args":{"command_name": "build-import"}},
     { "caption": "LSP-metals: Build Connect", "command": "lsp_execute", "args":{"command_name": "build-connect"}},
-    { "caption": "LSP-metals: Source Scan", "command": "lsp_execute", "args":{"command_name": "sources-scan"}},
+    { "caption": "LSP-metals: Compile Cascade", "command": "lsp_execute", "args":{"command_name": "compile-cascade"}},
+    { "caption": "LSP-metals: Compile Cancel", "command": "lsp_execute", "args":{"command_name": "compile-cancel"}},
     { "caption": "LSP-metals: Doctor Run", "command": "lsp_execute", "args":{"command_name": "doctor-run"}}
 ]


### PR DESCRIPTION
http://scalameta.org/metals/docs/editors/new-editor.html#metals-server-commands
I added what I thought are the most common commands. 
The main goal is to get rid of [this](http://scalameta.org/metals/docs/editors/sublime.html#manually-trigger-build-import) configuration step 