### PR TITLE
add menu entry allowing the user to set metals settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "preferences",
+    "children": [
+      {
+        "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "LSP",
+            "id": "lsp-settings",
+            "children": [
+              {
+                "caption": "Servers",
+                "id": "lsp-servers",
+                "children": [
+                  {
+                    "caption": "LSP-metals",
+                    "command": "edit_settings",
+                    "args": {
+                      "base_file": "${packages}/metals-sublime/metals-sublime.sublime-settings",
+                      "default": "{\n\t$0\n}\n"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Previously users weren't able to set the plugin settings like `server_version` or `server_properties`.
Now, users can go the plugin settings from sublime UI.
![Peek 2019-11-29 10-37](https://user-images.githubusercontent.com/1632384/69859326-3ad94a00-1294-11ea-828c-d472c7b08891.gif)

