### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-[Metals](https://scalameta.org/metals/) support for Sublime's [LSP](https://github.com/tomv564/LSP) plugin. Proving status bar support and other custom Metals LSP endpoints.
+[Metals](https://scalameta.org/metals/) support for Sublime's [LSP](https://github.com/tomv564/LSP) plugin. Providing status bar support and other custom Metals LSP endpoints.
 
 * Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-metals` from Package Control.
 * Restart Sublime.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # About
-A sublime plugin for [Metals](https://scalameta.org/metals/) proving status bar support and other custom Metals LSP endpoints.
 
-# Installation
-1. Install sublime [LSP](https://github.com/tomv564/LSP) plugin.
-2. In sublime's command palette type `Package Control: Add Repository`.
-3. At the bottom of the Sublime window, an input box will appear. Paste the URL of this repository (https://github.com/scalameta/metals-sublime).
-4. Finally, in sublime's command palette type `Package Control: Install Packages` and select `metals-sublime`. 
-5. Once the installation complete, the package is enabled by default and you should see notifications in the status bar.  
+[Metals](https://scalameta.org/metals/) support for Sublime's [LSP](https://github.com/tomv564/LSP) plugin. Proving status bar support and other custom Metals LSP endpoints.
+
+* Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-metals` from Package Control.
+* Restart Sublime.
+
+### Configuration
+
+Configure the metals language server by accessing `Preferences > Package Settings > LSP > Servers > LSP-metals`.


### PR DESCRIPTION
Previously users had to install the plugin by cloning this repository, now they can install the plugin directly via Sublime's package control.

Thanks @rwols for the heads up