### PR TITLE
Listen to metals/executeClientCommand and handle metals-goto-location

### DIFF
--- a/metals-sublime.sublime-settings
+++ b/metals-sublime.sublime-settings
@@ -8,6 +8,7 @@
   "server_properties": [
     "-Dmetals.client=sublime",
     "-Dmetals.status-bar=on",
+    "-Dmetals.execute-client-command=on",
     "-Xss4m",
     "-Xms100m"
   ],


### PR DESCRIPTION
Previously LSP-metals wasn't handling the `metals/executeClientCommand` notification. 
Now it is handled in addition to the `metals-goto-location` command which improves the user experience when using the `Create new symbol '$name'...` code action https://github.com/scalameta/metals/pull/1528

fixes #14 

