### PR TITLE
Support new-scala-file command as well as metals/inputBox request

### DIFF
--- a/LSP-metals.sublime-commands
+++ b/LSP-metals.sublime-commands
@@ -3,5 +3,6 @@
     { "caption": "LSP-metals: Build Connect", "command": "lsp_execute", "args":{"command_name": "build-connect"}},
     { "caption": "LSP-metals: Compile Cascade", "command": "lsp_execute", "args":{"command_name": "compile-cascade"}},
     { "caption": "LSP-metals: Compile Cancel", "command": "lsp_execute", "args":{"command_name": "compile-cancel"}},
-    { "caption": "LSP-metals: Doctor Run", "command": "lsp_execute", "args":{"command_name": "doctor-run"}}
+    { "caption": "LSP-metals: Doctor Run", "command": "lsp_execute", "args":{"command_name": "doctor-run"}},
+    { "caption": "LSP-metals: New Scala File", "command": "new_scala_file", "args":{"paths": []}}
 ]

--- a/README.md
+++ b/README.md
@@ -115,11 +115,14 @@ To troubleshoot problems with your build workspace, run `Doctor run` in the comm
 
 ### All Available Commands
 
+The following commands can be invoked simply via the sublime command palette.
+
   - [Build Import](https://scalameta.org/metals/docs/editors/new-editor.html#import-build)
   - [Build Connect](https://scalameta.org/metals/docs/editors/new-editor.html#connect-to-build-server)
   - [compile Cascade](https://scalameta.org/metals/docs/editors/new-editor.html#cascade-compile)
   - [Compile Cancel](https://scalameta.org/metals/docs/editors/new-editor.html#cancel-compilation)
   - [Doctor Run](https://scalameta.org/metals/docs/editors/new-editor.html#run-doctor)
+  - [New Scala File](https://scalameta.org/metals/docs/editors/new-editor.html#create-new-scala-file): Also available in the side bar context menu. ![Peek 2020-07-19 16-48](https://user-images.githubusercontent.com/1632384/87877673-e5e37300-c9df-11ea-9516-6fccb221e3f6.gif) 
 
 
 ### Show document symbols

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,0 +1,8 @@
+[
+  {
+    "caption": "New Scala File",
+    "id": "new_scala_file",
+    "command": "new_scala_file",
+    "args": {"paths": []}
+  }
+]

--- a/commands.py
+++ b/commands.py
@@ -1,15 +1,10 @@
 import sublime
+import sublime_plugin
 from LSP.plugin.core.url import filename_to_uri
-from LSP.plugin.core.registry import LspTextCommand
 
-class NewScalaFileCommand(LspTextCommand):
+class NewScalaFileCommand(sublime_plugin.TextCommand):
 
-    def is_enabled(self, event: 'Optional[dict]' = None) -> bool:
-        return super().is_enabled() or bool(self.session('executeCommandProvider'))
-
-    def run(self, 
-            edit: sublime.Edit,
-            paths) -> None:
+    def run(self, edit: sublime.Edit, paths) -> None:
         if(paths):
           args = {
             "command_name": "new-scala-file",

--- a/commands.py
+++ b/commands.py
@@ -5,9 +5,14 @@ from LSP.plugin.core.url import filename_to_uri
 class NewScalaFileCommand(sublime_plugin.TextCommand):
 
     def run(self, edit: sublime.Edit, paths) -> None:
+        view = sublime.active_window().active_view()
+        path = ''
         if(paths):
-          args = {
+            path = paths[0]
+        else:
+            path = view.file_name()
+        args = {
             "command_name": "new-scala-file",
-            "command_args": [filename_to_uri(paths[0])]
-          }
-          sublime.active_window().active_view().run_command("lsp_execute", args)
+            "command_args": [filename_to_uri(path)]
+        }
+        view.run_command("lsp_execute", args)

--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,18 @@
+import sublime
+from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.registry import LspTextCommand
+
+class NewScalaFileCommand(LspTextCommand):
+
+    def is_enabled(self, event: 'Optional[dict]' = None) -> bool:
+        return super().is_enabled() or bool(self.session('executeCommandProvider'))
+
+    def run(self, 
+            edit: sublime.Edit,
+            paths) -> None:
+        if(paths):
+          args = {
+            "command_name": "new-scala-file",
+            "command_args": [filename_to_uri(paths[0])]
+          }
+          sublime.active_window().active_view().run_command("lsp_execute", args)

--- a/commands.py
+++ b/commands.py
@@ -5,14 +5,12 @@ from LSP.plugin.core.url import filename_to_uri
 class NewScalaFileCommand(sublime_plugin.TextCommand):
 
     def run(self, edit: sublime.Edit, paths) -> None:
-        view = sublime.active_window().active_view()
-        path = ''
         if(paths):
             path = paths[0]
         else:
-            path = view.file_name()
+            path = self.view.file_name()
         args = {
             "command_name": "new-scala-file",
             "command_args": [filename_to_uri(path)]
         }
-        view.run_command("lsp_execute", args)
+        self.view.run_command("lsp_execute", args)

--- a/commands.py
+++ b/commands.py
@@ -5,10 +5,7 @@ from LSP.plugin.core.url import filename_to_uri
 class NewScalaFileCommand(sublime_plugin.TextCommand):
 
     def run(self, edit: sublime.Edit, paths) -> None:
-        if(paths):
-            path = paths[0]
-        else:
-            path = self.view.file_name()
+        path = paths[0] if paths else self.view.file_name()
         args = {
             "command_name": "new-scala-file",
             "command_args": [filename_to_uri(path)]

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,3 @@
+init_options = {
+  'inputBoxProvider': True
+}

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,3 @@
 init_options = {
-  'inputBoxProvider': True
+    'inputBoxProvider': True
 }

--- a/plugin.py
+++ b/plugin.py
@@ -116,12 +116,8 @@ def register_client(client):
 
 def on_metals_inputbox(client, params, request_id):
     def send_response(input: 'Optional[str]' = None):
-        if input:
-            param = { 'value': input, 'cancelled': False }
-        else:
-            param = {'cancelled': True}
-        response = Response(request_id, param)
-        client.send_response(response)
+        param = { 'value': input, 'cancelled': False } if input else {'cancelled': True}
+        client.send_response(Response(request_id, param))
 
     sublime.active_window().show_input_panel(
         params.get('prompt', ''),

--- a/plugin.py
+++ b/plugin.py
@@ -116,9 +116,10 @@ def register_client(client):
 
 def on_metals_inputbox(client, params, request_id):
     def send_response(input: 'Optional[str]' = None):
-        param = {'cancelled': True}
         if input:
-            param.update({'value': input, 'cancelled': False })
+            param = { 'value': input, 'cancelled': False }
+        else:
+            param = {'cancelled': True}
         response = Response(request_id, param)
         client.send_response(response)
 

--- a/plugin.py
+++ b/plugin.py
@@ -4,8 +4,8 @@ import sublime
 from LSP.plugin.core.handlers import LanguageHandler
 from LSP.plugin.core.settings import ClientConfig, LanguageConfig
 from LSP.plugin.core.url import uri_to_filename
-from LSP.plugin.core.protocol import Location
-
+from LSP.plugin.core.protocol import Location, Response
+from .constants import init_options
 
 server_name = 'LSP-metals'
 settings_file = 'LSP-metals.sublime-settings'
@@ -71,7 +71,7 @@ class LspMetalsPlugin(LanguageHandler):
             tcp_port=None,
             languages=[language],
             enabled=True,
-            init_options=dict(),
+            init_options=init_options,
             settings=dict(),
             env=dict())
         self._name = server_name
@@ -110,6 +110,26 @@ def register_client(client):
     client.on_notification(
         "metals/executeClientCommand",
         lambda params: on_execute_client_command(params))
+    client.on_request(
+        "metals/inputBox",
+        lambda params, request_id: on_metals_inputbox(client, params, request_id))
+
+def on_metals_inputbox(client, params, request_id):
+    def send_response(input: 'Optional[str]' = None):
+        param = {'cancelled': True}
+        if input:
+            param.update({'value': input, 'cancelled': False })
+        response = Response(request_id, param)
+        client.send_response(response)
+
+    sublime.active_window().show_input_panel(
+        params.get('prompt', ''),
+        params.get('value', ''),
+        lambda value: send_response(value),
+        None,
+        lambda: send_response(None)
+    )
+
 
 def on_metals_status(params):
     view = sublime.active_window().active_view()


### PR DESCRIPTION
Previously sublime users weren't able to take advantage of the [new scala file](https://scalameta.org/metals/blog/2020/02/26/cobalt.html#new-file-provider) features from Metals. 
This PR solves this problem.

  
![Peek 2020-07-19 16-48](https://user-images.githubusercontent.com/1632384/87877673-e5e37300-c9df-11ea-9516-6fccb221e3f6.gif)

@rchl @rwols Do you know a way to make `NewScalaFileCommand` enabled and visible only if a `LSP-metals` session is running ?
  
Fixes #15 