### PR TITLE
Don't start server when workspace is undefined.

### DIFF
--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -39,6 +39,11 @@ class Metals(AbstractPlugin):
         workspace_folders: List[WorkspaceFolder],
         configuration: ClientConfig
     ) -> Optional[str]:
+        rootPath = configuration.init_options.get('rootPath')
+        rootUri = configuration.init_options.get('rootUri')
+        if not workspace_folders and not rootPath and not rootUri :
+            return "No workspace detected. Try opening your project at the workspace root."
+
         plugin_settings = sublime.load_settings("LSP-metals.sublime-settings")
         java_path = get_java_path(plugin_settings)
         if not java_path :

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -39,9 +39,7 @@ class Metals(AbstractPlugin):
         workspace_folders: List[WorkspaceFolder],
         configuration: ClientConfig
     ) -> Optional[str]:
-        rootPath = configuration.init_options.get('rootPath')
-        rootUri = configuration.init_options.get('rootUri')
-        if not workspace_folders and not rootPath and not rootUri :
+        if not workspace_folders :
             return "No workspace detected. Try opening your project at the workspace root."
 
         plugin_settings = sublime.load_settings("LSP-metals.sublime-settings")


### PR DESCRIPTION
fixes https://github.com/scalameta/metals-sublime/issues/30

@rwols is checking `workspace_folders` alone is enough or `rootPath` and `rootUri` are also required ? 