### PR TITLE
Always look up the session name for lsp_execute

### DIFF
--- a/LSP-metals.sublime-commands
+++ b/LSP-metals.sublime-commands
@@ -1,9 +1,9 @@
 [
-    { "caption": "LSP-metals: Build Import", "command": "lsp_execute", "args":{"command_name": "build-import"}},
-    { "caption": "LSP-metals: Build Connect", "command": "lsp_execute", "args":{"command_name": "build-connect"}},
-    { "caption": "LSP-metals: Compile Cascade", "command": "lsp_execute", "args":{"command_name": "compile-cascade"}},
-    { "caption": "LSP-metals: Compile Cancel", "command": "lsp_execute", "args":{"command_name": "compile-cancel"}},
-    { "caption": "LSP-metals: Doctor Run", "command": "lsp_execute", "args":{"command_name": "doctor-run"}},
+    { "caption": "LSP-metals: Build Import", "command": "lsp_metals_execute", "args":{"command_name": "build-import"}},
+    { "caption": "LSP-metals: Build Connect", "command": "lsp_metals_execute", "args":{"command_name": "build-connect"}},
+    { "caption": "LSP-metals: Compile Cascade", "command": "lsp_metals_execute", "args":{"command_name": "compile-cascade"}},
+    { "caption": "LSP-metals: Compile Cancel", "command": "lsp_metals_execute", "args":{"command_name": "compile-cancel"}},
+    { "caption": "LSP-metals: Doctor Run", "command": "lsp_metals_execute", "args":{"command_name": "doctor-run"}},
     { "caption": "LSP-metals: New Scala File", "command": "new_scala_file", "args":{"paths": []}},
     {
         "caption": "LSP-metals: Settings",

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,5 +1,6 @@
 from LSP.plugin.core.types import Optional, List
-from LSP.plugin.core.url import filename_to_uri
+from LSP.plugin.core.url import filename_to_uri  # TODO: deprecated in a future version
+from LSP.plugin.execute_command import LspExecuteCommand  # TODO: bring to public API
 import os
 import sublime
 import sublime_plugin
@@ -49,4 +50,8 @@ class NewScalaFileCommand(sublime_plugin.TextCommand):
             "command_name": "new-scala-file",
             "command_args": [filename_to_uri(path)]
         }
-        self.view.run_command("lsp_execute", args)
+        self.view.run_command("lsp_metals_execute", args)
+
+
+class LspMetalsExecuteCommand(LspExecuteCommand):
+    session_name = "metals"

--- a/st3/__init__.py
+++ b/st3/__init__.py
@@ -1,5 +1,6 @@
 from ..common import create_launch_command
 from ..common import get_java_path
+from ..common import LspMetalsExecuteCommand
 from ..common import NewScalaFileCommand
 from ..common import prepare_server_properties
 from LSP.plugin.core.collections import DottedDict
@@ -11,6 +12,7 @@ import sublime
 
 server_name = 'LSP-metals'
 settings_file = 'LSP-metals.sublime-settings'
+LspMetalsExecuteCommand.session_name = server_name
 
 
 class LspMetalsPlugin(LanguageHandler):

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -1,6 +1,7 @@
 from ..common import create_launch_command
 from ..common import get_java_path
 from ..common import NewScalaFileCommand
+from ..common import LspMetalsExecuteCommand
 from ..common import prepare_server_properties
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import register_plugin


### PR DESCRIPTION
This should start working for ST4 again while maintaining compatilibity with ST3. The improvement is that we always look for a session called "metals". Previously, the lsp_execute command could just as well pick another more suitable session that happens to be running alongside metals.