### PR TITLE
Handle metals/publishDecorations (ST4 only) 

### DIFF
--- a/LSP-metals.sublime-settings
+++ b/LSP-metals.sublime-settings
@@ -21,6 +21,21 @@
 
   // initialization options
   "initializationOptions": {
-    "inputBoxProvider": true
+    "inputBoxProvider": true,
+    // (ST4 only) When enabled, shows worksheet evaluations as Sublime.Phantom instead of code comments.
+    "decorationProvider": false,
+    // (ST4 only) When enabled, inferred types and implicits are shown as as Sublime.Phantom.
+    "inlineDecorationProvider": false
+  },
+
+  "settings": {
+    "metals": {
+      // (ST4 only) When enabled, each method and variable that can have inferred types has them displayed.
+      "show-inferred-type": false,
+      // (ST4 only) When enabled, each method that has implicit arguments has them displayed.
+      "show-implicit-arguments": false,
+      // (ST4 only) When enabled, each place where an implicit method or class is used has it displayed.
+      "show-implicit-conversions-and-classes": false
+    }
   }
 }

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -10,13 +10,20 @@ from LSP.plugin import unregister_plugin
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin import ClientConfig
 from LSP.plugin.core.types import Optional, Dict, Any, Tuple, List
+from LSP.plugin.core.views import range_to_region, FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
+from LSP.plugin.core.css import css
+from LSP.plugin.core.protocol import Range
 import sublime
+import mdpopups
+from functools import reduce
 
 # TODO: Bring to public API
 from LSP.plugin.core.views import location_to_encoded_filename
 
 
 class Metals(AbstractPlugin):
+
+    phantom_key = "metals_decoraction"
 
     @classmethod
     def name(cls) -> str:
@@ -51,6 +58,7 @@ class Metals(AbstractPlugin):
         if not server_version :
             return "'server_version' setting should be set"
 
+
     # notification and request handlers
 
     def m_metals_status(self, params: Any) -> None:
@@ -65,6 +73,32 @@ class Metals(AbstractPlugin):
             session.set_window_status_async(key, params.get('text', ''))
         else:
             session.erase_window_status_async(key)
+
+    def m_metals_publishDecorations(self, decorationsParams: Any) -> None:
+        if not isinstance(decorationsParams, dict):
+            return
+
+        session = self.weaksession()
+        if not session:
+            return
+
+        uri = decorationsParams.get('uri')
+        if not uri:
+            return
+
+        session_buffer = session.get_session_buffer_for_uri_async(uri)
+        if not session_buffer:
+            return
+
+        for sv in session_buffer.session_views:
+            try:
+                phantom_set = getattr(sv, "_lsp_metals_decorations")
+            except AttributeError:
+                phantom_set = sublime.PhantomSet(sv.view, self.phantom_key)
+                setattr(sv, "_lsp_metals_decorations", phantom_set)
+
+            phantom_set.update(decorations_to_phantom(decorationsParams.get('options', []), sv.view))
+
 
     def m_metals_executeClientCommand(self, params: Any) -> None:
         """Handle the metals/executeClientCommand notification."""
@@ -101,6 +135,53 @@ class Metals(AbstractPlugin):
             lambda: send_response(None)
         )
 
+PHANTOM_HTML = """
+<style>div.phantom {{font-style: italic; color: {}}}</style>
+<div class='phantom'>{}{}</div>"""
+
+def show_popup(content: Dict[str, Any], view: sublime.View, location: int):
+    html = minihtml(view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT)
+    viewport_width = view.viewport_extent()[0]
+    mdpopups.show_popup(
+        view,
+        html,
+        css=css().popups,
+        md=False,
+        flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+        location=location,
+        wrapper_class=css().popups_classname,
+        max_width=viewport_width,
+        on_navigate=None)
+
+
+def decoration_to_phantom(option: Dict[str, Any], view: sublime.View) -> Optional[sublime.Phantom]:
+    decorationRange = Range.from_lsp(option['range'])
+    region = range_to_region(decorationRange, view)
+    region.a = region.b  # make the start point equal to the end point
+    hoverMessage = deep_get(option, 'hoverMessage')
+    contentText = deep_get(option, 'renderOptions', 'after', 'contentText')
+    link = ''
+    point = None
+    if hoverMessage:
+        link = " <a href='more'>more</a>"
+        point = view.text_point(decorationRange.start.row, decorationRange.start.col)
+
+    color = view.style_for_scope("comment")["foreground"]
+    phantomContent = PHANTOM_HTML.format(color, contentText, link)
+    phantom = sublime.Phantom(
+        region,
+        phantomContent,
+        sublime.LAYOUT_INLINE,
+        lambda href: show_popup(hoverMessage, view, point))
+
+    return phantom
+
+def decorations_to_phantom(options: Dict[str, Any], view: sublime.View) -> List[sublime.Phantom]:
+    return map(lambda o: decoration_to_phantom(o, view), options)
+
+
+def deep_get(dictionary: Dict[str, Any], *keys):
+    return reduce(lambda d, key: d.get(key) if d else None, keys, dictionary)
 
 def plugin_loaded() -> None:
     register_plugin(Metals)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1632384/106180076-23e5fe80-619c-11eb-8f45-233c22b8632c.png)

@ckipp01 @tgodzik

As you can see in the example above infered types work fine. But the implicit parameter `(x)` is off. It should be on the right i.e. `f("hello")(x)`. Any idea why metals sends the wrong LSP region ?

This feature is limited to ST4 only: [Comment](https://github.com/scalameta/metals-sublime/pull/36#issuecomment-773569076)

TODO:
- [x] Handle `hoverMessage`
- [x] Handle view closure