### PR TITLE
Implement metals/didFocusTextDocument notification

### DIFF
--- a/LSP-metals.sublime-settings
+++ b/LSP-metals.sublime-settings
@@ -19,6 +19,7 @@
 
   // initialization options
   "initializationOptions": {
+    "didFocusProvider": true,
     "executeClientCommandProvider": true,
     "statusBarProvider": true,
     "inputBoxProvider": true,

--- a/st4/LspMetalsFocus.py
+++ b/st4/LspMetalsFocus.py
@@ -1,0 +1,33 @@
+from LSP.plugin.core.registry import LspTextCommand
+from LSP.plugin.core.types import Optional, Dict, Any
+from LSP.plugin.core.protocol import Notification
+
+import sublime
+import sublime_plugin
+import functools
+
+class LspMetalsFocusViewCommand(LspTextCommand):
+
+    session_name = "metals"
+
+    def run(self, edit: sublime.Edit, view_id: int, event: Optional[Dict[str, Any]] = None) -> None:
+        view = sublime.View(view_id)
+        if not view.is_valid():
+            return
+        fname = view.file_name()
+        if not fname:
+            return
+        sublime.set_timeout_async(functools.partial(self.run_async, fname))
+
+    def run_async(self, fname: str) -> None:
+        session = self.session_by_name()
+        if not session:
+            return
+        uri = session.config.map_client_path_to_server_uri(fname)
+        session.send_notification(Notification("metals/didFocusTextDocument", {"uri": uri}))
+
+
+class ActiveViewListener(sublime_plugin.EventListener):
+    def on_activated(self, view: sublime.View) -> None:
+        if view.file_name():
+            view.run_command("lsp_metals_focus_view", {"view_id": view.id()})

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -16,6 +16,7 @@ from LSP.plugin.core.protocol import Range
 import sublime
 import mdpopups
 from functools import reduce
+from . LspMetalsFocus import LspMetalsFocusViewCommand, ActiveViewListener
 
 # TODO: Bring to public API
 from LSP.plugin.core.views import location_to_encoded_filename


### PR DESCRIPTION
Send [metals/didFocusTextDocument](https://scalameta.org/metals/docs/integrations/new-editor.html#metalsdidfocustextdocument) on view focus.

All credit goes to @rwols for making this feature work. 