### PR TITLE
Send range with textDocument/hover

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,7 @@
+[
+    // Show Type annotation on code selection
+    // {
+    //     "command": "lsp_metals_hover_range",
+    //     "keys": ["UNBOUND"]
+    // }
+]

--- a/st4/LspMetalsHoverRange.py
+++ b/st4/LspMetalsHoverRange.py
@@ -1,0 +1,48 @@
+from LSP.plugin.core.registry import LspTextCommand
+from LSP.plugin.core.typing import Union
+from LSP.plugin.core.protocol import Request, Range, TextDocumentIdentifier, Error, Hover
+from LSP.plugin.core.views import first_selection_region, text_document_identifier, region_to_range, FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml, update_lsp_popup, show_lsp_popup
+import sublime
+
+HoverOrError = Union[Hover, Error]
+
+class LspMetalsHoverRangeCommand(LspTextCommand):
+    session_name = "metals"
+
+    def run(self, edit: sublime.Edit) -> None:
+        session = self.session_by_name()
+        if not session:
+            return
+        view = self.view
+        region = first_selection_region(view)
+        begin = region.begin()
+        document_range = {
+            "textDocument": text_document_identifier(view),
+            "range": region_to_range(view, region).to_lsp()
+        }
+
+        def on_response(response: HoverOrError):
+            if isinstance(response, Error):
+                sublime.status_message('Hover error: {}'.format(response))
+
+            if response:
+                content = (response.get('contents') or '') if isinstance(response, dict) else ''
+                formated = minihtml(self.view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT)
+                if self.view.is_popup_visible():
+                    update_lsp_popup(self.view, formated)
+                else:
+                    show_lsp_popup(
+                        self.view,
+                        formated,
+                        flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                        location=begin
+                    )
+
+        def on_error(error: Error):
+            sublime.status_message('Hover error: {}'.format(error))
+
+        session.send_request(
+            Request("textDocument/hover", document_range, self.view),
+            on_response,
+            on_error
+        )

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -17,6 +17,7 @@ import sublime
 import mdpopups
 from functools import reduce
 from . LspMetalsFocus import LspMetalsFocusViewCommand, ActiveViewListener
+from . LspMetalsHoverRange import LspMetalsHoverRangeCommand
 
 # TODO: Bring to public API
 from LSP.plugin.core.views import location_to_encoded_filename


### PR DESCRIPTION
This is needed to handle https://github.com/scalameta/metals/pull/3060
It should be handle by LSP package once https://github.com/microsoft/language-server-protocol/issues/377
is resolved

![Peek 2021-11-14 21-54](https://user-images.githubusercontent.com/1632384/141698283-0a246666-9ad3-4cfd-b309-0cdaf09f0476.gif)


@rwols @rchl I duplicated some code that is in [hover.py](https://github.com/sublimelsp/LSP/blob/c1e25f0378b7338d6a46a6f2f7c1d522d7e95999/plugin/hover.py). If you think this behavior change should in https://github.com/sublimelsp/LSP let me know.

Todo:
 - [ ] Update readme to mention the required keybinding
 
 closes https://github.com/scalameta/metals-sublime/issues/44