### PR TITLE
Basic support for metals/findTextInDependencyJars

### DIFF
--- a/LSP-metals.sublime-commands
+++ b/LSP-metals.sublime-commands
@@ -13,6 +13,7 @@
     { "caption": "LSP-metals: Show semanticdb", "command": "file_decoder", "args":{"decoding_type": "semanticdb-compact"}},
     { "caption": "LSP-metals: Show semanticdb detailed", "command": "file_decoder", "args":{"decoding_type": "semanticdb-detailed"}},
     { "caption": "LSP-metals: Show semanticdb proto", "command": "file_decoder", "args":{"decoding_type": "semanticdb-proto"}},
+    { "caption": "LSP-metals: Find in dependency", "command": "find_in_dependency", "args":{}},
     { "caption": "LSP-metals: New Scala File", "command": "new_scala_file", "args":{"paths": []}},
     { "caption": "LSP-metals: Analyze Stacktrace", "command": "analyze_stacktrace"},
     {

--- a/st4/FindInDependency.py
+++ b/st4/FindInDependency.py
@@ -1,0 +1,59 @@
+from LSP.plugin.core.protocol import Request, Location
+from LSP.plugin.core.registry import LspTextCommand
+from LSP.plugin.core.sessions import Session
+from LSP.plugin.core.typing import Any, List, Union, Dict
+from LSP.plugin.locationpicker import LocationPicker
+import weakref
+
+import sublime
+import sublime_plugin
+
+class IncludeInput(sublime_plugin.TextInputHandler):
+    def validate(self, txt: str) -> bool:
+        return txt != ""
+
+    def placeholder(self) -> str:
+        return "File filter"
+
+class PatternInput(sublime_plugin.TextInputHandler):
+    def validate(self, txt: str) -> bool:
+        return txt != ""
+
+    def placeholder(self) -> str:
+        return "Text pattern to search for"
+
+    def next_input(handler, value):
+        return IncludeInput()
+
+class FindInDependencyCommand(LspTextCommand):
+    _command = "metals/findTextInDependencyJars"
+    session_name = "metals"
+
+    def input(self, _args: Any) -> sublime_plugin.TextInputHandler:
+        return PatternInput()
+
+    def run(self, edit: sublime.Edit, pattern_input: str, include_input: str) -> None:
+        if pattern_input and include_input:
+            session = self.session_by_name()
+            if session:
+                params = {
+                    "query": {"pattern": pattern_input},
+                    "options": {"include": include_input}
+                  }
+                request = Request(self._command, params, None, progress=True)
+                self.weaksession = weakref.ref(session)
+                session.send_request(request, self._handle_response, self._handle_error)
+
+    def _handle_response(self, response: Union[List[Location], None]) -> None:
+        if response:
+            locations = response
+            session = self.weaksession()
+            self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
+            LocationPicker(self.view, session, locations, side_by_side=False)
+        else:
+            sublime.message_dialog("No matches found")
+
+    def _handle_error(self, error: Dict[str, Any]) -> None:
+        reason = error.get("message", "none provided by server :(")
+        msg = "command '{}' failed. Reason: {}".format(self._command, reason)
+        sublime.error_message(msg)

--- a/st4/FindInDependency.py
+++ b/st4/FindInDependency.py
@@ -48,8 +48,9 @@ class FindInDependencyCommand(LspTextCommand):
         if response:
             locations = response
             session = self.weaksession()
-            self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
-            LocationPicker(self.view, session, locations, side_by_side=False)
+            if session:
+                self.view.run_command("add_jump_record", {"selection": [(r.a, r.b) for r in self.view.sel()]})
+                LocationPicker(self.view, session, locations, side_by_side=False)
         else:
             sublime.message_dialog("No matches found")
 

--- a/st4/__init__.py
+++ b/st4/__init__.py
@@ -18,6 +18,7 @@ import mdpopups
 from functools import reduce
 from . LspMetalsFocus import LspMetalsFocusViewCommand, ActiveViewListener
 from . FileDecoder import FileDecoderCommand
+from . FindInDependency import FindInDependencyCommand
 from . AnalyzeStacktrace import AnalyzeStacktraceCommand
 from . OpenFileEncoded import OpenFileEncodedCommand
 from urllib.parse import urlparse,unquote


### PR DESCRIPTION
https://scalameta.org/metals/docs/integrations/new-editor/#metalsfindtextindependencyjars
Similar to neo-vim and vs-code implementations only `query.pattern` and `options.include` are included in the request.


![Peek 2021-11-27 21-03](https://user-images.githubusercontent.com/1632384/143720713-d93e6998-ab7a-4995-bcb6-ddc38db3f52f.gif)

Closes https://github.com/scalameta/metals-sublime/issues/47