### PR TITLE
Clear exiting phantoms when worksheet is being edited

### DIFF
--- a/core/decorations.py
+++ b/core/decorations.py
@@ -1,20 +1,46 @@
-from functools import reduce
+from .. commands.lsp_metals_text_command import LspMetalsTextCommand
+from functools import reduce, partial
 from LSP.plugin.core.css import css
 from LSP.plugin.core.protocol import Range
 from LSP.plugin.core.sessions import Session
-from LSP.plugin.core.typing import Any, List, Dict, Optional
+from LSP.plugin.core.typing import Any, List, Dict, Optional, Union
 from LSP.plugin.core.views import range_to_region, FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
+
 import mdpopups
 import sublime
+import sublime_plugin
 
 
-def handle_publish_decorations(session: Session, decorations_params: Any) -> None:
+class WorksheetListener(sublime_plugin.ViewEventListener):
+    def on_modified(self) -> None:
+        file_name = self.view.file_name()
+        if file_name and file_name.endswith('.worksheet.sc'):
+            self.view.run_command('lsp_metals_clear_phantoms')
+
+class LspMetalsClearPhantomsCommand(LspMetalsTextCommand):
+    def run(self, edit: sublime.Edit) -> None:
+        fname = self.view.file_name()
+        if not fname:
+            return
+        sublime.set_timeout_async(partial(self.run_async, fname))
+
+    def run_async(self, fname: str) -> None:
+        session = self.session_by_name()
+        if not session:
+            return
+        handle_decorations(session, fname)
+
+def handle_decorations(session: Session, params: Union[Dict[str, Any], str]) -> None:
     phantom_key = "metals_decoraction"
     field_name = "_lsp_metals_decorations"
-    if not isinstance(decorations_params, dict):
-        return
+    clear_phantoms = False
+    uri = None
+    if isinstance(params, str):
+        uri = session.config.map_client_path_to_server_uri(params)
+        clear_phantoms = True
+    elif isinstance(params, dict):
+        uri = params.get('uri')
 
-    uri = decorations_params.get('uri')
     if not uri:
         return
 
@@ -23,13 +49,17 @@ def handle_publish_decorations(session: Session, decorations_params: Any) -> Non
         return
     session_view = next(iter(session_buffer.session_views), None)
     if session_view:
+        phantoms = []
         try:
             phantom_set = getattr(session_buffer, field_name)
         except AttributeError:
             phantom_set = sublime.PhantomSet(session_view.view, phantom_key)
             setattr(session_buffer, field_name, phantom_set)
 
-        phantom_set.update(decorations_to_phantom(decorations_params.get('options', []), session_view.view))
+        if not clear_phantoms:
+            phantoms = decorations_to_phantom(params.get('options', []), session_view.view)
+
+        phantom_set.update(phantoms)
 
 PHANTOM_HTML = """
 <style>div.phantom {{font-style: italic; color: {}}}</style>

--- a/core/metals.py
+++ b/core/metals.py
@@ -1,4 +1,4 @@
-from . decorations import handle_publish_decorations
+from . decorations import handle_decorations
 from . handle_execute_client import handle_execute_client
 from . handle_input_box import handle_input_box
 from . status import handle_status
@@ -55,7 +55,7 @@ class Metals(AbstractPlugin):
         session = self.weaksession()
         if not session:
             return
-        handle_publish_decorations(session, decorationsParams)
+        handle_decorations(session, decorationsParams)
 
     def m_metals_executeClientCommand(self, params: Any) -> None:
         session = self.weaksession()

--- a/plugin.py
+++ b/plugin.py
@@ -24,6 +24,7 @@ else:
     from . commands.lsp_metals_new_scala_file import LspMetalsNewScalaFileCommand
     from . commands.lsp_metals_open_file_encoded import LspMetalsOpenFileEncodedCommand
     from . commands.lsp_metals_text_command import LspMetalsTextCommand
+    from . core.decorations import WorksheetListener, LspMetalsClearPhantomsCommand
     from . core.metals import Metals
 
     def plugin_loaded() -> None:


### PR DESCRIPTION
Worksheets can contain quite a lot of phantoms and it can be messy when several edits are needed.
Also the phantoms are obsolete during the edit because the worksheet needs to be re-evaluated anyways.
So here we clear the phantoms on the first edit

![Peek 2021-12-20 23-02](https://user-images.githubusercontent.com/1632384/146838923-a3f75edc-946a-4ced-b623-5f8e30ee6fcd.gif)
