### PR TITLE
Allow open location to take in the `otherWindow` parameter

### DIFF
--- a/commands/utils.py
+++ b/commands/utils.py
@@ -22,7 +22,7 @@ def get_session(window: sublime.Window) -> Optional[Session]:
 
     return metals_session
 
-def open_location(window: sublime.Window, location: Location) -> None:
+def open_location(window: sublime.Window, location: Dict) -> None:
     uri = location['uri']
     r = location['range']
     (_, path) = parse_uri(uri)


### PR DESCRIPTION
Not 100% if this will work, related to the changes in https://github.com/scalameta/metals/pull/3540/files

@ayoub-benali could you test it out after the other PR is merged and released?