### PR TITLE
Implement metals-goto-location command to fix stacktrace analysis links

### DIFF
--- a/commands/lsp_metals_goto_position.py
+++ b/commands/lsp_metals_goto_position.py
@@ -8,3 +8,9 @@ class LspMetalsGotoPositionCommand(sublime_plugin.WindowCommand):
     def run(self, parameters: List[Any]) -> None:
         if isinstance(parameters, list) and parameters:
             open_location(self.window, parameters[0])
+
+class LspMetalsMetalsGotoLocationCommand(sublime_plugin.WindowCommand):
+
+    def run(self, parameters: List[Any]) -> None:
+        if isinstance(parameters, list) and parameters:
+            open_location(self.window, parameters[0])

--- a/commands/lsp_metals_metals_goto_location.py
+++ b/commands/lsp_metals_metals_goto_location.py
@@ -3,12 +3,6 @@ from LSP.plugin.core.types import List, Any
 
 import sublime_plugin
 
-class LspMetalsGotoPositionCommand(sublime_plugin.WindowCommand):
-
-    def run(self, parameters: List[Any]) -> None:
-        if isinstance(parameters, list) and parameters:
-            open_location(self.window, parameters[0])
-
 class LspMetalsMetalsGotoLocationCommand(sublime_plugin.WindowCommand):
 
     def run(self, parameters: List[Any]) -> None:

--- a/plugin.py
+++ b/plugin.py
@@ -21,7 +21,7 @@ else:
     from . commands.lsp_metals_find_in_dependency import LspMetalsFindInDependencyCommand
     from . commands.lsp_metals_focus import LspMetalsFocusViewCommand, ActiveViewListener
     from . commands.lsp_metals_goto import LspMetalsGoto
-    from . commands.lsp_metals_goto_position import LspMetalsGotoPositionCommand, LspMetalsMetalsGotoLocationCommand
+    from . commands.lsp_metals_metals_goto_location import LspMetalsMetalsGotoLocationCommand
     from . commands.lsp_metals_goto_super_method import LspMetalsSendPositionCommand
     from . commands.lsp_metals_new_scala_file import LspMetalsNewScalaFileCommand
     from . commands.lsp_metals_text_command import LspMetalsTextCommand

--- a/plugin.py
+++ b/plugin.py
@@ -21,7 +21,7 @@ else:
     from . commands.lsp_metals_find_in_dependency import LspMetalsFindInDependencyCommand
     from . commands.lsp_metals_focus import LspMetalsFocusViewCommand, ActiveViewListener
     from . commands.lsp_metals_goto import LspMetalsGoto
-    from . commands.lsp_metals_goto_position import LspMetalsGotoPositionCommand
+    from . commands.lsp_metals_goto_position import LspMetalsGotoPositionCommand, LspMetalsMetalsGotoLocationCommand
     from . commands.lsp_metals_goto_super_method import LspMetalsSendPositionCommand
     from . commands.lsp_metals_new_scala_file import LspMetalsNewScalaFileCommand
     from . commands.lsp_metals_text_command import LspMetalsTextCommand


### PR DESCRIPTION
@ckipp01 @tgodzik My understanding from https://github.com/scalameta/metals/pull/3540 is that the links in stracktrace analysis migrated from `goto-position` to `metals-goto-location`, can I delete the support of the former command from this plugin ? 