### PR TITLE
Add accept latest-stable and latest-snapshot as server versions

### DIFF
--- a/LSP-metals.sublime-settings
+++ b/LSP-metals.sublime-settings
@@ -1,6 +1,7 @@
 {
   // The version of the Metals server artifact. Requires restarting sublime.
-  "server_version": "0.11.6",
+  // latest-stable, latest-snapshot or a specific server version
+  "server_version": "latest-stable",
 
   // Optional path to the Java home directory. Requires reloading sublime.
   "java_home": "",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ instructions in the displayed error message.
 In order to install the latest snapshot of metals you can explicitly set the snapshot version for `server_version`. Alternatively, you can also just default to the latest snapshot by setting `server_version` to `latest-snapshot`.
 The same can be done for the latest stable release by setting the value to `latest-stable`, If no version is set, it defaults to the latest stable release as well.
 
-These new release check in done each time sublime text is started.
+The new release check in done each time sublime text is started.
 
 ### Workplace Diagnostic
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ instructions in the displayed error message.
 
 #### Server version
 
-To use the latest Metals SNAPSHOT update the `server_version` setting to try out the latest pending Metals features.
-After updating the version, you need to restart sublime.
+In order to install the latest snapshot of metals you can explicitly set the snapshot version for `server_version`. Alternatively, you can also just default to the latest snapshot by setting `server_version` to `latest-snapshot`.
+The same can be done for the latest stable release by setting the value to `latest-stable`, If no version is set, it defaults to the latest stable release as well.
+
+These new release check in done each time sublime text is started.
 
 ### Workplace Diagnostic
 

--- a/core/metals.py
+++ b/core/metals.py
@@ -3,16 +3,20 @@ from . handle_execute_client import handle_execute_client
 from . handle_input_box import handle_input_box
 from . status import handle_status
 from .. commands.lsp_metals_text_command import LspMetalsTextCommand
+from distutils.version import LooseVersion
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
 from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.types import Optional, Any, Tuple, List
-from distutils.version import LooseVersion
+from urllib.request import urlopen, Request
+import json
 
 import sublime
 import os
 
 _COURSIER_PATH = os.path.join(os.path.dirname(__file__), '..', 'coursier')
+_LATEST_STABLE = "latest-stable"
+_LATEST_SNAPSHOT = "latest-snapshot"
 
 class Metals(AbstractPlugin):
 
@@ -35,9 +39,22 @@ class Metals(AbstractPlugin):
         java_path = get_java_path(plugin_settings)
         if not java_path :
             return "Please install java or set the 'java_home' setting"
-        server_version = plugin_settings.get('server_version')
-        if not server_version :
-            return "'server_version' setting should be set"
+        server_version = plugin_settings.get('server_version', _LATEST_STABLE)
+        if server_version == _LATEST_STABLE or server_version == _LATEST_SNAPSHOT:
+            try:
+                httprequest = Request(
+                    "https://scalameta.org/metals/latests.json",
+                    headers={"Accept": "application/json"},
+                    method="GET"
+                )
+                httpresponse = urlopen(httprequest)
+                body = json.loads(httpresponse.read().decode())
+                if server_version == _LATEST_SNAPSHOT:
+                    server_version = body.get("snapshot")
+                else:
+                    server_version = body.get("release")
+            except:
+                return "Couldn't get latest version number from scalameta website, please set the 'server_version'"
 
         properties = prepare_server_properties(plugin_settings.get("server_properties"))
         command = create_launch_command(java_path, server_version, properties)

--- a/core/metals.py
+++ b/core/metals.py
@@ -40,7 +40,7 @@ class Metals(AbstractPlugin):
         if not java_path :
             return "Please install java or set the 'java_home' setting"
         server_version = plugin_settings.get('server_version', _LATEST_STABLE)
-        if server_version == _LATEST_STABLE or server_version == _LATEST_SNAPSHOT:
+        if not server_version or server_version == _LATEST_STABLE or server_version == _LATEST_SNAPSHOT:
             try:
                 httprequest = Request(
                     "https://scalameta.org/metals/latests.json",


### PR DESCRIPTION
Fix https://github.com/scalameta/metals-sublime/issues/61

I am not sure if this exactly the same behavior as the vscode and vim plugins.
@tgodzik are the other clients released now with `latest-stable` a default server version ?

cc @ninth-dev



