### PR TITLE
Add run scalafix command

### DIFF
--- a/LSP-metals.sublime-commands
+++ b/LSP-metals.sublime-commands
@@ -47,9 +47,10 @@
             "command_args": ["${file_uri}"]
         }
     },
-     {
+    {
         "caption": "LSP-metals: Show Build Target Info",
         "command": "lsp_metals_show_build_target_info",
         "args": {"command_name": "list-build-targets"}
-    }   
+    },
+    { "caption": "LSP-metals: Run Scalafix", "command": "lsp_metals_run_scalafix"}
 ]

--- a/commands/lsp_metals_run_scalafix.py
+++ b/commands/lsp_metals_run_scalafix.py
@@ -1,0 +1,16 @@
+from . lsp_metals_text_command import LspMetalsTextCommand
+from LSP.plugin.core.views import text_document_position_params, first_selection_region
+
+import sublime
+
+class LspMetalsRunScalafixCommand(LspMetalsTextCommand):
+
+    def run(self, edit: sublime.Edit) -> None:
+        region = first_selection_region(self.view)
+        if region is not None:
+            point = region.begin()
+            args = {
+                "command_name": "scalafix-run",
+                "command_args": [text_document_position_params(self.view, point)]
+            }
+            self.view.run_command("lsp_metals_execute", args)

--- a/plugin.py
+++ b/plugin.py
@@ -16,17 +16,18 @@ elif sublime.version() < '4000':
     sublime.error_message('This version requires st4, use the st3 branch')
 else:
     from . commands.lsp_metals_analyze_stacktrace import LspMetalsAnalyzeStacktraceCommand
+    from . commands.lsp_metals_copy_worksheet import LspMetalsCopyWorksheetCommand
     from . commands.lsp_metals_execute_command import LspMetalsExecuteCommand
     from . commands.lsp_metals_file_decoder import LspMetalsFileDecoderCommand
     from . commands.lsp_metals_find_in_dependency import LspMetalsFindInDependencyCommand
     from . commands.lsp_metals_focus import LspMetalsFocusViewCommand, ActiveViewListener
     from . commands.lsp_metals_goto import LspMetalsGoto
-    from . commands.lsp_metals_metals_goto_location import LspMetalsMetalsGotoLocationCommand
     from . commands.lsp_metals_goto_super_method import LspMetalsSendPositionCommand
+    from . commands.lsp_metals_metals_goto_location import LspMetalsMetalsGotoLocationCommand
+    from . commands.lsp_metals_run_scalafix import LspMetalsRunScalafixCommand
     from . commands.lsp_metals_show_build_target_info import LspMetalsShowBuildTargetInfoCommand
     from . commands.lsp_metals_text_command import LspMetalsTextCommand
     from . core.decorations import WorksheetListener, LspMetalsClearPhantomsCommand
-    from . commands.lsp_metals_copy_worksheet import LspMetalsCopyWorksheetCommand
     from . core.metals import Metals
 
     def plugin_loaded() -> None:


### PR DESCRIPTION
I was always possible to run scalafix rules on file save by setting 
```
"lsp_code_actions_on_save":{
  "source.organizeImports": frue
}
 ``` 
 But this commands gives another option for the user

![Peek 2022-09-17 18-50](https://user-images.githubusercontent.com/1632384/190867784-837b3b52-b139-46f6-8451-7c4e91cb672f.gif)

Fix https://github.com/scalameta/metals-sublime/issues/95