### PR TITLE
Use public imports and adapt to new LSP version

### DIFF
--- a/core/decorations.py
+++ b/core/decorations.py
@@ -1,8 +1,6 @@
 from .. commands.lsp_metals_text_command import LspMetalsTextCommand
 from functools import reduce, partial
-from LSP.plugin.core.css import css
-from LSP.plugin.core.protocol import Range
-from LSP.plugin.core.sessions import Session
+from LSP.plugin import css, Session
 from LSP.plugin.core.typing import Any, List, Dict, Optional, Union
 from LSP.plugin.core.views import range_to_region, FORMAT_MARKED_STRING, FORMAT_MARKUP_CONTENT, minihtml
 
@@ -17,6 +15,7 @@ class WorksheetListener(sublime_plugin.ViewEventListener):
         if file_name and file_name.endswith('.worksheet.sc'):
             self.view.run_command('lsp_metals_clear_phantoms')
 
+
 class LspMetalsClearPhantomsCommand(LspMetalsTextCommand):
     def run(self, edit: sublime.Edit) -> None:
         fname = self.view.file_name()
@@ -29,6 +28,7 @@ class LspMetalsClearPhantomsCommand(LspMetalsTextCommand):
         if not session:
             return
         handle_decorations(session, fname)
+
 
 def handle_decorations(session: Session, params: Union[Dict[str, Any], str]) -> None:
     phantom_key = "metals_decoraction"
@@ -61,9 +61,11 @@ def handle_decorations(session: Session, params: Union[Dict[str, Any], str]) -> 
 
         phantom_set.update(phantoms)
 
+
 PHANTOM_HTML = """
 <style>div.phantom {{font-style: italic; color: {}}}</style>
 <div class='phantom'>{}{}</div>"""
+
 
 def show_popup(content: Dict[str, Any], view: sublime.View, location: int) -> None:
     html = minihtml(view, content, allowed_formats=FORMAT_MARKED_STRING | FORMAT_MARKUP_CONTENT)
@@ -81,13 +83,12 @@ def show_popup(content: Dict[str, Any], view: sublime.View, location: int) -> No
 
 
 def decoration_to_phantom(option: Dict[str, Any], view: sublime.View) -> Optional[sublime.Phantom]:
-    decoration_range = Range.from_lsp(option['range'])
-    region = range_to_region(decoration_range, view)
+    region = range_to_region(option['range'], view)
     region.a = region.b  # make the start point equal to the end point
     hoverMessage = deep_get(option, 'hoverMessage')
     contentText = deep_get(option, 'renderOptions', 'after', 'contentText')
     link = ''
-    point = view.text_point(decoration_range.start.row, decoration_range.start.col)
+    point = view.text_point(option['start'].row, option['start'].col)
     if hoverMessage:
         link = " <a href='more'>more</a>"
 
@@ -101,8 +102,10 @@ def decoration_to_phantom(option: Dict[str, Any], view: sublime.View) -> Optiona
 
     return phantom
 
+
 def decorations_to_phantom(options: Dict[str, Any], view: sublime.View) -> List[sublime.Phantom]:
     return map(lambda o: decoration_to_phantom(o, view), options)
+
 
 def deep_get(dictionary: Dict[str, Any], *keys):
     return reduce(lambda d, key: d.get(key) if d else None, keys, dictionary)

--- a/core/handle_execute_client.py
+++ b/core/handle_execute_client.py
@@ -1,10 +1,9 @@
 from collections import OrderedDict
 from . status import status_key
 from .. commands.utils import open_location
-from LSP.plugin.core.sessions import Session
+from LSP.plugin import Session
 from LSP.plugin.core.types import Any
 import json
-import sublime
 import mdpopups
 
 
@@ -26,17 +25,20 @@ def handle_execute_client(session: Session, params: Any) -> None:
         msg = "Unknown command {}".format(command_name)
         session.set_window_status_async(status_key, msg)
 
+
 def goto_location(session: Session, args: Any) -> None:
     """https://scalameta.org/metals/docs/integrations/new-editor/#goto-location"""
 
     if isinstance(args, list) and args:
         open_location(session.window, args[0])
 
+
 def show_stacktrace(session: Session, args: Any) -> None:
     """https://scalameta.org/metals/docs/integrations/new-editor/#show-the-stacktrace-in-the-client"""
 
     if isinstance(args, list) and args:
         session.window.new_html_sheet('Stacktrace', args[0])
+
 
 def run_doctor(session: Session, args: Any) -> None:
     if isinstance(args, list) and args:

--- a/core/handle_input_box.py
+++ b/core/handle_input_box.py
@@ -1,6 +1,6 @@
-from LSP.plugin import Response
-from LSP.plugin.core.sessions import Session
+from LSP.plugin import Response, Session
 from LSP.plugin.core.types import Optional, Any
+
 
 def handle_input_box(session: Session, params: Any, request_id: Any) -> None:
     """Handle the metals/inputBox request."""
@@ -8,7 +8,7 @@ def handle_input_box(session: Session, params: Any, request_id: Any) -> None:
         return
 
     def send_response(input: Optional[str]) -> None:
-        p = { 'value': input, 'cancelled': False } if input else {'cancelled': True}
+        p = {'value': input, 'cancelled': False} if input else {'cancelled': True}
         session.send_response(Response(request_id, p))
 
     session.window.show_input_panel(

--- a/core/metals.py
+++ b/core/metals.py
@@ -7,7 +7,7 @@ from distutils.version import LooseVersion
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import ClientConfig
 from LSP.plugin import WorkspaceFolder
-from LSP.plugin.core.types import Optional, Any, Tuple, List
+from LSP.plugin.core.types import Optional, Any, List
 from urllib.request import urlopen, Request
 import json
 
@@ -17,6 +17,7 @@ import os
 _COURSIER_PATH = os.path.join(os.path.dirname(__file__), '..', 'coursier')
 _LATEST_STABLE = "latest-stable"
 _LATEST_SNAPSHOT = "latest-snapshot"
+
 
 class Metals(AbstractPlugin):
 
@@ -88,6 +89,7 @@ class Metals(AbstractPlugin):
             return
         handle_input_box(session, params, request_id)
 
+
 def get_java_path(settings: sublime.Settings) -> str:
     java_home = settings.get("java_home")
     if isinstance(java_home, str) and java_home:
@@ -96,6 +98,7 @@ def get_java_path(settings: sublime.Settings) -> str:
     if java_home:
         return os.path.join(java_home, "bin", "java")
     return "java"
+
 
 def create_launch_command(java_path: str, artifact_version: str, server_properties: List[str]) -> List[str]:
     binary_version = "2.12"

--- a/core/status.py
+++ b/core/status.py
@@ -1,7 +1,8 @@
+from LSP.plugin import Session
 from LSP.plugin.core.types import Any
-from LSP.plugin.core.sessions import Session
 
 status_key = "metals-status"
+
 
 def handle_status(session: Session, params: Any) -> None:
     """Handle the metals/status notification."""


### PR DESCRIPTION
- Switch to importing from public LSP exports, where available. Otherwise things can potentially break in the future.
- Adapted to latest version of LSP (not released yet at the time of writing) where the `Range` class was removed.
- Some minor linting fixes (I'm running flake8 locally)

Those changes can be released at any point after the next version of LSP is released.