### PR TITLE
fix: handle new doctor version v5 

### DIFF
--- a/core/handle_execute_client.py
+++ b/core/handle_execute_client.py
@@ -103,7 +103,7 @@ def run_doctor(session: Session, args: Any) -> None:
         header = content.get('header')
         markdown = "# {} \n\n".format(content.get('title'))
 
-        if doctor_version == 4:
+        if doctor_version >= 4:
             header_fields = [
                 'buildTargetDescription',
                 'serverInfo',


### PR DESCRIPTION
Since the new doctor version (v5), doctor was not showing anything. 

<img width="493" alt="Screenshot 2023-12-29 at 5 06 05 pm" src="https://github.com/scalameta/metals-sublime/assets/4069123/c2a4e52f-7108-4c08-94b1-70f8f205944d">

Note, this PR doesn't parse and show the new [errorReports](https://github.com/scalameta/metals/pull/5786). We can raise a separate PR to address that.
