### PR TITLE
Use the file decoder provider to open URI with jar: ( Take 2 )

### DIFF
--- a/LSP-metals.sublime-settings
+++ b/LSP-metals.sublime-settings
@@ -9,6 +9,8 @@
   // Attach to views with base scope source.scala or source.java
   "selector": "source.scala, source.java",
 
+  "schemes": ["file", "jar"],
+
   // Optional array of properties to pass along to the Metals server.
   // Example: `-Dhttps.proxyHost=… -Dhttps.proxyPort=…` or `-Dmetals.statistics=all`
   // check https://scalameta.org/metals/docs/integrations/new-editor/#metals-server-properties for all properties

--- a/core/metals.py
+++ b/core/metals.py
@@ -100,13 +100,19 @@ class Metals(AbstractPlugin):
             if isinstance(response, Error) or 'error' in response:
                 handle_error("file-decode", response)
             if response and 'value' in response:
-                basename = os.path.basename(response['requestedUri'])
+
+                title = response['requestedUri']
+                uri_parts = str(response['requestedUri']).split("!")
+                if len(uri_parts) == 2:
+                    jar_source, path_to_file = uri_parts
+                    title = f"{os.path.basename(jar_source)}!{path_to_file}"
+
                 syntax = "Packages/Scala/Scala.sublime-syntax"
-                if basename.endswith('.java'):
+                if title.endswith('.java'):
                     syntax = "Packages/Java/Java.sublime-syntax"
 
                 callback(
-                    basename,
+                    title,
                     response['value'],
                     syntax
                 )


### PR DESCRIPTION
This solves #118. 

Thanks @rchl for explaning how to enable LSP for custom URIs.

The difference between this PR and #119 is that: 

- This PR will not create a "temp" readonly file in the .metals folder.
- This PR uses the `callback` in "on_open_uri_async", which means it can jump to the correct line / column. 