### PR TITLE
Update method for printing messages to the status bar

### DIFF
--- a/core/handle_execute_client.py
+++ b/core/handle_execute_client.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from . status import status_key
 from .. commands.utils import open_location
 from LSP.plugin import Session
 from LSP.plugin.core.types import Any
@@ -23,7 +22,7 @@ def handle_execute_client(session: Session, params: Any) -> None:
         run_doctor(session, args)
     else:
         msg = "Unknown command {}".format(command_name)
-        session.set_window_status_async(status_key, msg)
+        session.window.status_message(msg)
 
 
 def goto_location(session: Session, args: Any) -> None:

--- a/core/status.py
+++ b/core/status.py
@@ -1,8 +1,6 @@
 from LSP.plugin import Session
 from LSP.plugin.core.types import Any
 
-status_key = "metals-status"
-
 
 def handle_status(session: Session, params: Any) -> None:
     """Handle the metals/status notification."""
@@ -11,6 +9,6 @@ def handle_status(session: Session, params: Any) -> None:
         return
     hide = params.get("hide") if isinstance(params.get("hide"), bool) else False
     if not hide:
-        session.set_window_status_async(status_key, params.get('text', ''))
+        session.set_config_status_async(params.get('text', ''))
     else:
-        session.erase_window_status_async(status_key)
+        session.set_config_status_async('')


### PR DESCRIPTION
I'd like to deprecate the `Session.set_window_status_async` method in LSP, because there is also the newer `Session.set_config_status_async` which does basically the same thing.

The only change from this PR should be that the messages from `metals/status` notifications will be shown in brackets directly after the server name in the status bar.