### PR TITLE
Fix a small breaking change

### DIFF
--- a/commands/lsp_metals_focus.py
+++ b/commands/lsp_metals_focus.py
@@ -1,6 +1,5 @@
 from . lsp_metals_text_command import LspMetalsTextCommand
 from LSP.plugin.core.protocol import Notification
-from LSP.plugin.core.types import Optional, Dict, Any
 
 import sublime
 import sublime_plugin

--- a/core/handle_input_box.py
+++ b/core/handle_input_box.py
@@ -1,5 +1,5 @@
 from LSP.plugin import Response, Session
-from LSP.plugin.core.types import Optional, Any
+from typing import Optional, Any
 
 
 def handle_input_box(session: Session, params: Any, request_id: Any) -> None:


### PR DESCRIPTION
Hello 👋 

LSP for Sublime Text plan to release LSP 2.9.0 soonish
and it contains a small change that breaks this plugin.

Optional is no longer exported from LSP, 
but we can import it directly from typing. (Optional was removed in this commit https://github.com/sublimelsp/LSP/commit/ead1085da645c6ad71e2efa9a3104b276502e605#diff-476d0275847cfb60ebc00c73c76d5c5e6595f5b70dd8c659d4f0fd1a854f49eeL27)


It would be good to merge this.
And create a new LSP-metals release.

cc @ayoub-benali 