### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-metals.sublime-settings
+++ b/LSP-metals.sublime-settings
@@ -21,7 +21,7 @@
   ],
 
   // initialization options
-  "initializationOptions": {
+  "initialization_options": {
     "didFocusProvider": true,
     "executeClientCommandProvider": true,
     "statusBarProvider": "on",


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
